### PR TITLE
Uart fix

### DIFF
--- a/lib/utils/serial/litex-uart.c
+++ b/lib/utils/serial/litex-uart.c
@@ -20,32 +20,39 @@
 #define UART_REG_EV_PENDING	4
 #define UART_REG_EV_ENABLE	5
 
+#define UART_EV_TX	0x1
+#define UART_EV_RX	0x2
+
+
 /* clang-format on */
 
 static volatile u32 *uart_base;
 
-static u8 get_reg(u8 reg)
+static u32 get_reg(u32 reg)
 {
-	return readb(uart_base + reg);
+	return readl(uart_base + reg);
 }
 
-static void set_reg(u8 reg, u8 val)
+static void set_reg(u32 reg, u32 val)
 {
-	writeb(val, uart_base + reg);
+	writel(val, uart_base + reg);
 }
 
 static void litex_uart_putc(char ch)
 {
 	while (get_reg(UART_REG_TXFULL));
 	set_reg(UART_REG_RXTX, ch);
+	set_reg(UART_REG_EV_PENDING, UART_EV_TX);
 }
 
 static int litex_uart_getc(void)
 {
 	if (get_reg(UART_REG_RXEMPTY))
 		return -1;
-	else
-		return get_reg(UART_REG_RXTX);
+
+	u32 rx = get_reg(UART_REG_RXTX);
+	set_reg(UART_REG_EV_PENDING, UART_EV_RX);
+	return rx;
 }
 
 static struct sbi_console_device litex_console = {


### PR DESCRIPTION
Hi,

I had issue with opensbi when trying to log in linux via SBI / HVC0,  getc wasn't clearing the event flag.

I moved the register access to u32 aswell to follow what was done on the linux driver (if i remember well)

Tested on hardware with NaxRiscv and VexiiRiscv